### PR TITLE
[BUGFIX] Avoid class imports in configuration files

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,12 +1,10 @@
 <?php
 declare(strict_types=1);
 
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-
 defined('TYPO3_MODE') || die('Access denied.');
 
 // Add Default TS to Include static (from extensions)
-ExtensionManagementUtility::addStaticFile(
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
     'easycaptcha',
     'Configuration/TypoScript/',
     'Easy Captcha'

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,24 +1,19 @@
 <?php
 
-use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
-use TYPO3\CMS\Core\Imaging\IconRegistry;
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-
 (static function () {
 
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']['EXT:form/Resources/Private/Language/Database.xlf'][] =
         'EXT:easycaptcha/Resources/Private/Language/Backend.xlf';
 
-    /** @var IconRegistry $iconRegistry */
-    $iconRegistry = GeneralUtility::makeInstance(IconRegistry::class);
+    /** @var \TYPO3\CMS\Core\Imaging\IconRegistry $iconRegistry */
+    $iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Imaging\IconRegistry::class);
     $iconRegistry->registerIcon(
         't3-form-icon-easycaptcha',
-        SvgIconProvider::class,
+        \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
         ['source' => 'EXT:easycaptcha/Resources/Public/Icons/Extension.svg']
     );
 
-    ExtensionManagementUtility::addTypoScriptSetup('
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup('
 module.tx_form.settings.yamlConfigurations {
     1982 = EXT:easycaptcha/Configuration/Yaml/BaseSetup.yaml
     1983 = EXT:easycaptcha/Configuration/Yaml/FormEditorSetup.yaml
@@ -27,7 +22,7 @@ module.tx_form.settings.yamlConfigurations {
     $isComposerMode = defined('TYPO3_COMPOSER_MODE') && TYPO3_COMPOSER_MODE;
     if(!$isComposerMode) {
         // we load the autoloader for our libraries
-        $dir = ExtensionManagementUtility::extPath('easycaptcha');
+        $dir = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('easycaptcha');
         require $dir . '/Resources/Private/Php/Composer/vendor/autoload.php';
     }
 })();


### PR DESCRIPTION
According to best practices for configuration files, class imports should be avoided as stated in the official documentation:

> You must never use a use statement in the files global scope - that would make the cached script concept break and could conflict with other extensions.

([Source: docs.typo3.org](https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ConfigurationFiles/Index.html#best-practices-for-ext-tables-php-and-ext-localconf-php))

This commit removes existing class imports in TCA overrides and `ext_localconf.php` to avoid said problems.