### PR TITLE
Fix Flexform configurations ignores when language is set to all

### DIFF
--- a/Classes/Service/Image.php
+++ b/Classes/Service/Image.php
@@ -57,24 +57,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
         ->removeAll()
         ->add(GeneralUtility::makeInstance(DeletedRestriction::class))
         ->add(GeneralUtility::makeInstance(FrontendWorkspaceRestriction::class));
-
-    $statement = $queryBuilder
-        ->select('pi_flexform')
-        ->from('tt_content')
-        ->andWhere($queryBuilder->expr()->andX(
-            $queryBuilder->expr()->eq(
-                'sys_language_uid',
-                $queryBuilder->createNamedParameter($sys_language_uid, PDO::PARAM_INT)
-            ),
-            $queryBuilder->expr()->eq(
-                'pid',
-                $queryBuilder->createNamedParameter((int)$_GET['pid'], PDO::PARAM_INT)
-            ),
-            $queryBuilder->expr()->eq(
-                'CType',
-                $queryBuilder->createNamedParameter('form_formframework', PDO::PARAM_STR)
-            )
-        ))->execute();
             
         $statement = $queryBuilder
         ->select('pi_flexform')
@@ -113,8 +95,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
                 )
             ))->execute()->fetch();;
         }
-
-
     $result = $statement->fetch();
 
 

--- a/Classes/Service/Image.php
+++ b/Classes/Service/Image.php
@@ -75,6 +75,45 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
                 $queryBuilder->createNamedParameter('form_formframework', PDO::PARAM_STR)
             )
         ))->execute();
+            
+        $statement = $queryBuilder
+        ->select('pi_flexform')
+        ->from('tt_content');
+
+        $result = $statement->andWhere(
+            $queryBuilder->expr()->andX(
+                $queryBuilder->expr()->eq(
+                    'sys_language_uid',
+                    $queryBuilder->createNamedParameter($sys_language_uid, PDO::PARAM_INT)
+                ),
+                $queryBuilder->expr()->eq(
+                    'pid',
+                    $queryBuilder->createNamedParameter((int)$_GET['pid'], PDO::PARAM_INT)
+                ),
+                $queryBuilder->expr()->eq(
+                    'CType',
+                    $queryBuilder->createNamedParameter('form_formframework', PDO::PARAM_STR)
+                )
+            ))->execute()->fetch();
+
+        if (empty($res)) {
+            $result = $statement->orWhere(
+            $queryBuilder->expr()->andX(
+                $queryBuilder->expr()->eq(
+                    'sys_language_uid',
+                    $queryBuilder->createNamedParameter(-1, PDO::PARAM_INT)
+                ),
+                $queryBuilder->expr()->eq(
+                    'pid',
+                    $queryBuilder->createNamedParameter((int)$_GET['pid'], PDO::PARAM_INT)
+                ),
+                $queryBuilder->expr()->eq(
+                    'CType',
+                    $queryBuilder->createNamedParameter('form_formframework', PDO::PARAM_STR)
+                )
+            ))->execute()->fetch();;
+        }
+
 
     $result = $statement->fetch();
 


### PR DESCRIPTION
Flexform configurations are not found when the field `sys_language_uid` is `-1`.
TYPO3 sets the value of   `sys_language_uid` is ` field to  `-1` when a content element is configured to be used in all languages. 